### PR TITLE
Update google storage to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "bin": "./index.js",
   "license": "MIT",
   "dependencies": {
-    "@google-cloud/storage": "^0.3.0",
-    "yargs": "^6.2.0"
+    "@google-cloud/storage": "^0.4.0",
+    "yargs": "^6.3.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",


### PR DESCRIPTION
Do we want to set any of the new options?

https://github.com/GoogleCloudPlatform/google-cloud-node/releases/tag/storage-0.4.0

/cc @ivarconr 

I also added greenkeeper, so we should get PRs on new versions