### PR TITLE
Add validation and resumable options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ typings
 typings.json
 
 cdn-uploader-*
+
+.idea

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Options:
                                    [string] [default: "public, max-age=2592000"]
   --flatten, -f       Flatten filestructure           [boolean] [default: false]
   --dry-run, -n       Print a list of which files would be uploaded    [boolean]
+  --resumable, -r     Resumable upload                 [boolean] [default: true]
+  --validation, -V    Validation for upload            [boolean] [default: true]
   --help, -h, -?      Show help                                        [boolean]
   --version, -v       Show version number                              [boolean]
 ```

--- a/index.js
+++ b/index.js
@@ -52,6 +52,18 @@ const {argv} = require('yargs')
         describe: 'Print a list of which files would be uploaded',
         type: 'boolean',
     })
+    .option('resumable', {
+        alias: 'r',
+        describe: 'Resumable upload',
+        default: true,
+        type: 'boolean',
+    })
+    .option('validation', {
+        alias: 'V',
+        describe: 'Validation for upload',
+        default: true,
+        type: 'boolean',
+    })
     .help()
     .version()
     .alias('help', ['h', '?'])

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -3,9 +3,11 @@
 const { Storage } = require('@google-cloud/storage');
 const { isDirectory, makeAbsolute, getFilesToUpload } = require('./file-util');
 
-function uploadToGCS(bucket, cacheControl, asset) {
+function uploadToGCS(bucket, cacheControl, validate, resume, asset) {
     const uploadOpt = {
         destination: asset.destination,
+        validation: validate,
+        resumable: resume,
         public: true,
         gzip: true,
         metadata: { cacheControl },
@@ -14,7 +16,14 @@ function uploadToGCS(bucket, cacheControl, asset) {
 }
 
 function uploadToCloud(options, assets) {
-    const { projectId, credentials, bucketName, cacheControl } = options;
+    const {
+        projectId,
+        credentials,
+        bucketName,
+        cacheControl,
+        validation,
+        resumable,
+    } = options;
 
     const storage = new Storage({
         projectId,
@@ -24,7 +33,9 @@ function uploadToCloud(options, assets) {
     const bucket = storage.bucket(bucketName);
 
     return Promise.all(
-        assets.map(asset => uploadToGCS(bucket, cacheControl, asset))
+        assets.map(asset =>
+            uploadToGCS(bucket, cacheControl, validation, resumable, asset)
+        )
     );
 }
 


### PR DESCRIPTION
Some uploads randomly return checksum errors. These can be mitigated using
resumable: false (optionally validation: false)

See
- https://github.com/googleapis/google-cloud-node/issues/2604
- https://github.com/firebase/functions-samples/issues/140

Example error:

```$ ../../node_modules/@finn-no/cdn-uploader/index.js --credentials ${CDN_UPLOADER_CREDENTIALS} --project-id foo-storage --bucket-name foo-assets --app-prefix foo-web/_next build/next

/foo/node_modules/@google-cloud/storage/src/file.js:1093
        const error = new Error(message);
                      ^
Error: The uploaded data did not match the data from the server. As a precaution, the file has been deleted. To be sure the content is the same, you should try uploading the file again.
    at /foo/node_modules/@google-cloud/storage/src/file.js:1093:23
    at Object.handleResp (/foo/node_modules/@google-cloud/common/src/util.js:134:3)
    at /foo/node_modules/@google-cloud/common/src/util.js:496:12
    at Request.onResponse [as _callback] (/foo/node_modules/retry-request/index.js:198:7)
    at Request.self.callback (/foo/node_modules/request/request.js:185:22)```