### PR TITLE
Fix handling for uploading of a lot of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ return new Buffer(credentialString).toString('base64');
 Install:
 
 ```sh-session
-$ npm install @finn-no/cdn-uploader -g
+$ npm install @finn-no/cdn-uploader -g
 ```
 
 Actual usage:
 
 ```sh-session
-$ cdn-uploader /tmp/cdn-assets -a test-app
+$ cdn-uploader -a test-app /tmp/cdn-assets
 -- Uploaded assets --
 test-app/example.jpg
-test-app/css/SDFSDF.finn.css
-test-app/js/SDFSDF.finn.js
+test-app/css/example.css
+test-app/js/example.js
 ```
 
 Get help:
@@ -43,26 +43,28 @@ $ cdn-uploader -h
 cdn-uploader [options] <assetsFolder>
 
 Options:
-  --app-prefix, -a    Application prefix used in the CDN url [string] [required]
-  --key-filename, -k  JSON key file used to authenticate with Google Cloud
-                      Platform.
-                      If not set, the credentials option is used.       [string]
-  --credentials, -c   Stringified and base64 encoded version of the JSON key
-                      file used to authenticate with Google Cloud Platform.
-                      Can also be set as CDN_UPLOADER_CREDENTIALS environment
-                      variable                                          [string]
-  --bucket-name, -b   Google Cloud Storage bucket to use.
+  -a, --app-prefix     Application prefix used in the CDN url[string] [required]
+  -k, --key-filename   JSON key file used to authenticate with Google Cloud
+                       Platform.
+                       If not set, the credentials option is used.      [string]
+  -c, --credentials    Stringified and base64 encoded version of the JSON key
+                       file used to authenticate with Google Cloud Platform.
+                       Can also be set as CDN_UPLOADER_CREDENTIALS environment
+                       variable                                         [string]
+  -b, --bucket-name    Google Cloud Storage bucket to use.
                                               [string] [default: "fiaas-assets"]
-  --project-id, -p    Google Cloud Storage projectId.
+  -p, --project-id     Google Cloud Storage projectId.
                                                  [string] [default: "fiaas-gke"]
-  --cache-control     Override the cache-control header for the assets
+      --cache-control  Override the cache-control header for the assets
                                    [string] [default: "public, max-age=2592000"]
-  --flatten, -f       Flatten filestructure           [boolean] [default: false]
-  --dry-run, -n       Print a list of which files would be uploaded    [boolean]
-  --resumable, -r     Resumable upload                 [boolean] [default: true]
-  --validation, -V    Validation for upload            [boolean] [default: true]
-  --help, -h, -?      Show help                                        [boolean]
-  --version, -v       Show version number                              [boolean]
+  -f, --flatten        Flatten filestructure          [boolean] [default: false]
+  -n, --dry-run        Print a list of which files would be uploaded   [boolean]
+  -r, --resumable      Resumable upload                [boolean] [default: true]
+  -V, --validation     Validation for upload           [boolean] [default: true]
+  -s, --batch-size     How many files to upload in each batch
+                                                         [number] [default: 100]
+  -h, -?, --help       Show help                                       [boolean]
+  -v, --version        Show version number                             [boolean]
 ```
 
 All options can also be set as environment variables, using the `CDN_UPLOADER_`

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -1,6 +1,5 @@
-
-
 const { Storage } = require('@google-cloud/storage');
+const PromisePool = require('@supercharge/promise-pool');
 const { isDirectory, makeAbsolute, getFilesToUpload } = require('./file-util');
 
 function uploadToGCS(bucket, cacheControl, validate, resume, asset) {
@@ -15,7 +14,7 @@ function uploadToGCS(bucket, cacheControl, validate, resume, asset) {
     return bucket.upload(asset.path, uploadOpt).then(() => asset);
 }
 
-function uploadToCloud(options, assets) {
+async function uploadToCloud(options, assets) {
     const {
         projectId,
         credentials,
@@ -23,6 +22,7 @@ function uploadToCloud(options, assets) {
         cacheControl,
         validation,
         resumable,
+        batchSize,
     } = options;
 
     const storage = new Storage({
@@ -32,11 +32,12 @@ function uploadToCloud(options, assets) {
 
     const bucket = storage.bucket(bucketName);
 
-    return Promise.all(
-        assets.map(asset =>
+    return PromisePool
+        .for(assets)
+        .withConcurrency(batchSize)
+        .process(async (asset) =>
             uploadToGCS(bucket, cacheControl, validation, resumable, asset)
-        )
-    );
+        );
 }
 
 function getAllAssetsToUpload(options) {
@@ -53,6 +54,7 @@ function getAllAssetsToUpload(options) {
 
 function upload(options) {
     const assets = getAllAssetsToUpload(options);
+    console.log(`---Uploading ${assets.length} files---`)
 
     return uploadToCloud(options, assets);
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "license": "MIT",
     "dependencies": {
         "@google-cloud/storage": "5.8.5",
+        "@supercharge/promise-pool": "1.7.0",
         "chalk": "4.1.1",
         "fs-readdir-recursive": "1.1.0",
         "text-table": "0.2.0",
@@ -47,7 +48,8 @@
         "lint-staged": "11.0.0",
         "pkg": "5.2.1",
         "prettier": "2.3.1",
-        "rimraf": "3.0.2"
+        "rimraf": "3.0.2",
+        "sinon": "11.1.1"
     },
     "publishConfig": {
         "access": "public",

--- a/test/lib/file-util.test.js
+++ b/test/lib/file-util.test.js
@@ -20,7 +20,9 @@ test.before(async () => {
     ]);
 });
 
-test.after.always(() => {fs.remove(workPath)});
+test.after.always(async () => {
+    await fs.rm(workPath, { recursive: true, force: true })
+});
 
 test('should be a directory', t => {
     t.assert(fileUtil.isDirectory(workPath));

--- a/test/lib/uploader.test.js
+++ b/test/lib/uploader.test.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import os from 'os';
+import fs from 'fs-extra';
+import path from 'path';
+import sinon from 'sinon';
+import { upload } from '../../lib/uploader';
+
+const { Storage } = require('@google-cloud/storage');
+
+const workPath = path.join(os.tmpdir(), 'cdn-test');
+const nested = path.join(workPath, 'nested');
+const file1 = path.join(workPath, 'file1.txt');
+const file2 = path.join(workPath, 'file2.txt');
+const file3 = path.join(nested, 'file3.txt');
+
+test.before(async () => {
+    await fs.ensureDir(nested);
+
+    await Promise.all([
+        fs.writeFile(file1, 'woop1'),
+        fs.writeFile(file2, 'woop2'),
+        fs.writeFile(file3, 'woop3'),
+    ]);
+});
+
+test.after.always(async () => {
+    await fs.rm(workPath, { recursive: true, force: true })
+    sinon.restore()
+});
+
+test('should upload in batches', async t => {
+    const times = [];
+
+    sinon.stub(Storage.prototype, 'bucket').callsFake(() => ({
+        upload: () => {
+            times.push(new Date())
+            return new Promise(resolve => setTimeout(resolve, 10))
+        }
+    }));
+
+    const { results: uploadedAssets, errors } = await upload({
+        projectId: 'id',
+        credentials: 'cred',
+        bucketName: 'name',
+        appPrefix: 'prefix',
+        assetsFolder: workPath,
+        batchSize: 2
+    })
+
+    t.assert(uploadedAssets.length === 3)
+    t.assert(errors.length === 0)
+
+    t.assert(times.length === 3)
+    // The 2 first uploads are done at the same time (batch size == 2) and then the third is done later
+    t.assert(times[1].getMilliseconds() - times[0].getMilliseconds() < 2)
+    t.assert(times[2].getMilliseconds() - times[0].getMilliseconds() > 9)
+})


### PR DESCRIPTION
When having some thousand files to upload, running everything through
`Promise.all` will make the node process run out of resources, it
seems. This will instead use a promise pool of size x (configurable),
i.e. only x files will be uploaded at the same time before filling in with
new files.

Also add some more logging:
* number of files to upload
* files that failed somehow