### PR TITLE
Improve build and test GitHub Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Build and test
 
 on:
   push:
@@ -16,8 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,5 +25,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
-    - run: npm run travis --if-present
+    - run: npm ci
+    - run: npm run build-no-e2e --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/storage": "5.8.5",
+                "@supercharge/promise-pool": "1.7.0",
                 "chalk": "4.1.1",
                 "fs-readdir-recursive": "1.1.0",
                 "text-table": "0.2.0",
@@ -32,7 +33,8 @@
                 "lint-staged": "11.0.0",
                 "pkg": "5.2.1",
                 "prettier": "2.3.1",
-                "rimraf": "3.0.2"
+                "rimraf": "3.0.2",
+                "sinon": "11.1.1"
             }
         },
         "node_modules/@ava/babel-plugin-throws-helper": {
@@ -928,6 +930,49 @@
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/@sinonjs/samsam": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+            "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.6.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "node_modules/@supercharge/promise-pool": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.7.0.tgz",
+            "integrity": "sha512-OpnF7oqk6asrOUMhldnDju4RKeZ/iMAfw3LIoLdcTI53RZJLiQ9vEAcGW+bcBELXkiPhT7RqtuPSXAFF2iAmbg==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -3430,6 +3475,15 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/diff": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/dir-glob": {
@@ -6374,6 +6428,12 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
         "node_modules/jwa": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -6634,6 +6694,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
         "node_modules/lodash.islength": {
@@ -7314,6 +7380,19 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "node_modules/nise": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+            "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": ">=5",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
         },
         "node_modules/node-abi": {
             "version": "2.30.0",
@@ -8044,6 +8123,21 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
+        "node_modules/path-to-regexp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
             "dev": true
         },
         "node_modules/path-type": {
@@ -9352,6 +9446,24 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "node_modules/sinon": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+            "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": "^7.1.0",
+                "@sinonjs/samsam": "^6.0.2",
+                "diff": "^5.0.0",
+                "nise": "^5.1.0",
+                "supports-color": "^7.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10472,6 +10584,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/type-fest": {
@@ -11852,6 +11973,46 @@
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+        },
+        "@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+            "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.6.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "@supercharge/promise-pool": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.7.0.tgz",
+            "integrity": "sha512-OpnF7oqk6asrOUMhldnDju4RKeZ/iMAfw3LIoLdcTI53RZJLiQ9vEAcGW+bcBELXkiPhT7RqtuPSXAFF2iAmbg=="
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
@@ -13823,6 +13984,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "dev": true
+        },
+        "diff": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
             "dev": true
         },
         "dir-glob": {
@@ -16068,6 +16235,12 @@
                 "universalify": "^2.0.0"
             }
         },
+        "just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
         "jwa": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -16282,6 +16455,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
         "lodash.islength": {
@@ -16811,6 +16990,19 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "nise": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+            "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": ">=5",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
         },
         "node-abi": {
             "version": "2.30.0",
@@ -17369,6 +17561,23 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
         },
         "path-type": {
             "version": "3.0.0",
@@ -18340,6 +18549,20 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "sinon": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+            "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": "^7.1.0",
+                "@sinonjs/samsam": "^6.0.2",
+                "diff": "^5.0.0",
+                "nise": "^5.1.0",
+                "supports-color": "^7.2.0"
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -19254,6 +19477,12 @@
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
         },
         "type-fest": {
             "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@finn-no/cdn-uploader",
     "version": "3.3.0",
-    "description": "Small tool uploading assets to CDN backend (Google Cloud Storage)",
+    "description": "Small tool for uploading assets to CDN backend (Google Cloud Storage)",
     "main": "index.js",
     "files": [
         "index.js",
@@ -13,9 +13,10 @@
         "lint": "eslint .",
         "lint:format": "eslint --fix .",
         "test": "ava",
-        "travis": "npm run lint && npm run test && npm run travis:e2e && npm run create-executable && npm run travis:e2e-executable",
-        "travis:e2e": "./index.js -p cookies-kpi -b ivar-supertest -a e2e-test test/content",
-        "travis:e2e-executable": "./cdn-uploader-linux -p cookies-kpi -b ivar-supertest -a e2e-test test/content"
+        "build": "npm run lint && npm run test && npm run e2e-test && npm run create-executable && npm run e2e-test-executable",
+        "build-no-e2e": "npm run lint && npm run test && npm run create-executable",
+        "e2e-test": "./index.js -p cookies-kpi -b ivar-supertest -a e2e-test test/content",
+        "e2e-test-executable": "./cdn-uploader-linux -p cookies-kpi -b ivar-supertest -a e2e-test test/content"
     },
     "repository": "finn-no/cdn-uploader",
     "keywords": [


### PR DESCRIPTION
* have a more descriptive name of the GHA file for build and test
* do not build on node v12.x as it had some issues
* cannot run e2e tests yet as a GCS bucket is not available yet
* update `package-lock.json` so `npm ci` can be used again
* generalise `npm` task names, i.e. do not use `travis`