### PR TITLE
Support for node 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-    - 12
-    - 14
-    - 16
     - 18
     - 20
     - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
     - 12
     - 14
     - 16
+    - 18
+    - 20
     - stable
 before_install: yarn global add greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
-                "@google-cloud/storage": "5.8.5",
+                "@google-cloud/storage": "7.7.0",
                 "@supercharge/promise-pool": "1.7.0",
                 "chalk": "4.1.1",
                 "fs-readdir-recursive": "1.1.0",
@@ -754,43 +754,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@google-cloud/common": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
-            "integrity": "sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==",
-            "dependencies": {
-                "@google-cloud/projectify": "^2.0.0",
-                "@google-cloud/promisify": "^2.0.0",
-                "arrify": "^2.0.1",
-                "duplexify": "^4.1.1",
-                "ent": "^2.2.0",
-                "extend": "^3.0.2",
-                "google-auth-library": "^7.0.2",
-                "retry-request": "^4.1.1",
-                "teeny-request": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@google-cloud/common/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@google-cloud/paginator": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.5.tgz",
-            "integrity": "sha512-N4Uk4BT1YuskfRhKXBs0n9Lg2YTROZc6IMpkO/8DIHODtm5s3xY8K5vVBo23v/2XulY3azwITQlYWgT4GdLsUw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz",
+            "integrity": "sha512-87aeg6QQcEPxGCOthnpUjvw4xAZ57G7pL8FS0C4e/81fr3FjkpUpibf1s2v5XGyGhUVGF4Jfg7yEcxqn2iUw1w==",
             "dependencies": {
                 "arrify": "^2.0.0",
                 "extend": "^3.0.2"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@google-cloud/paginator/node_modules/arrify": {
@@ -802,69 +775,46 @@
             }
         },
         "node_modules/@google-cloud/projectify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.0.tgz",
-            "integrity": "sha512-qbpidP/fOvQNz3nyabaVnZqcED1NNzf7qfeOlgtAZd9knTwY+KtsGRkYpiQzcATABy4gnGP2lousM3S0nuWVzA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+            "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
             "engines": {
-                "node": ">=10"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@google-cloud/promisify": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
-            "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+            "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/@google-cloud/storage": {
-            "version": "5.8.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.5.tgz",
-            "integrity": "sha512-i0gB9CRwQeOBYP7xuvn14M40LhHCwMjceBjxE4CTvsqL519sVY5yVKxLiAedHWGwUZHJNRa7Q2CmNfkdRwVNPg==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.7.0.tgz",
+            "integrity": "sha512-EMCEY+6JiIkx7Dt8NXVGGjy1vRdSGdHkoqZoqjJw7cEBkT7ZkX0c7puedfn1MamnzW5SX4xoa2jVq5u7OWBmkQ==",
             "dependencies": {
-                "@google-cloud/common": "^3.6.0",
-                "@google-cloud/paginator": "^3.0.0",
-                "@google-cloud/promisify": "^2.0.0",
-                "arrify": "^2.0.0",
-                "async-retry": "^1.3.1",
+                "@google-cloud/paginator": "^5.0.0",
+                "@google-cloud/projectify": "^4.0.0",
+                "@google-cloud/promisify": "^4.0.0",
+                "abort-controller": "^3.0.0",
+                "async-retry": "^1.3.3",
                 "compressible": "^2.0.12",
-                "date-and-time": "^1.0.0",
                 "duplexify": "^4.0.0",
-                "extend": "^3.0.2",
-                "gaxios": "^4.0.0",
-                "gcs-resumable-upload": "^3.1.4",
-                "get-stream": "^6.0.0",
-                "hash-stream-validation": "^0.2.2",
-                "mime": "^2.2.0",
+                "ent": "^2.2.0",
+                "fast-xml-parser": "^4.3.0",
+                "gaxios": "^6.0.2",
+                "google-auth-library": "^9.0.0",
+                "mime": "^3.0.0",
                 "mime-types": "^2.0.8",
-                "onetime": "^5.1.0",
                 "p-limit": "^3.0.1",
-                "pumpify": "^2.0.0",
-                "snakeize": "^0.1.0",
-                "stream-events": "^1.0.1",
-                "xdg-basedir": "^4.0.0"
+                "retry-request": "^7.0.0",
+                "teeny-request": "^9.0.0",
+                "uuid": "^8.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=14"
             }
         },
         "node_modules/@google-cloud/storage/node_modules/p-limit": {
@@ -879,14 +829,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/xdg-basedir": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -987,12 +929,17 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "engines": {
-                "node": ">= 6"
+                "node": ">= 10"
             }
+        },
+        "node_modules/@types/caseless": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
         },
         "node_modules/@types/glob": {
             "version": "7.1.3",
@@ -1019,14 +966,29 @@
         "node_modules/@types/node": {
             "version": "15.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-            "dev": true
+            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
             "dev": true
+        },
+        "node_modules/@types/request": {
+            "version": "2.48.12",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+            "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+            "dependencies": {
+                "@types/caseless": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "form-data": "^2.5.0"
+            }
+        },
+        "node_modules/@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -1373,12 +1335,17 @@
             "dev": true
         },
         "node_modules/async-retry": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-            "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+            "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
             "dependencies": {
-                "retry": "0.12.0"
+                "retry": "0.13.1"
             }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
@@ -2062,9 +2029,9 @@
             ]
         },
         "node_modules/bignumber.js": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
             "engines": {
                 "node": "*"
             }
@@ -2264,7 +2231,7 @@
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.1",
@@ -2398,14 +2365,24 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001237",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-            "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==",
+            "version": "1.0.30001584",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001584.tgz",
+            "integrity": "sha512-LOz7CCQ9M1G7OjJOF9/mzmqmj3jE/7VOmrfw6Mgs0E8cjOsbRXQJHsPBfmBOXDskXKrHLyyW3n7kpDW/4BsfpQ==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ]
         },
         "node_modules/capture-stack-trace": {
             "version": "1.0.1",
@@ -2936,6 +2913,17 @@
             "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -3205,11 +3193,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/date-and-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.1.tgz",
-            "integrity": "sha512-7u+uNfnjWkX+YFQfivvW24TjaJG6ahvTrfw1auq7KlC7osuGcZBIWGBvB9UcENjH6JnLVhMqlRripk1dSHjAUA=="
-        },
         "node_modules/date-time": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
@@ -3223,9 +3206,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -3459,6 +3442,14 @@
                 "rimraf": "bin.js"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3537,9 +3528,9 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "node_modules/duplexify": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-            "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "dependencies": {
                 "end-of-stream": "^1.4.1",
                 "inherits": "^2.0.3",
@@ -3548,9 +3539,9 @@
             }
         },
         "node_modules/duplexify/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3633,7 +3624,7 @@
         "node_modules/ent": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-            "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+            "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
         },
         "node_modules/equal-length": {
             "version": "1.0.1",
@@ -4819,10 +4810,26 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
-        "node_modules/fast-text-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+        "node_modules/fast-xml-parser": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz",
+            "integrity": "sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastq": {
             "version": "1.11.0",
@@ -4914,6 +4921,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
             }
         },
         "node_modules/fragment-cache": {
@@ -5064,110 +5084,46 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-            "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.2.0.tgz",
+            "integrity": "sha512-H6+bHeoEAU5D6XNc6mPKeN5dLZqEDs9Gpk6I+SZBEzK5So58JVrHPmevNi35fRl1J9Y5TaeLW0kYx3pCJ1U2mQ==",
             "dependencies": {
-                "abort-controller": "^3.0.0",
                 "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^7.0.1",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.3.0"
+                "node-fetch": "^2.6.9"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            }
+        },
+        "node_modules/gaxios/node_modules/agent-base": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gaxios/node_modules/https-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/gaxios/node_modules/is-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcp-metadata": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-            "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
-            "dependencies": {
-                "gaxios": "^4.0.0",
-                "json-bigint": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/gcs-resumable-upload": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.2.0.tgz",
-            "integrity": "sha512-k6OAkrO0N1zgvwTRxgCC43K9BMvNUBhZkkFELsMSlgAVs7Sd9C1TA9pmDLBZmFBN8sdvrObsSbCfOOFnHULRvA==",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "configstore": "^5.0.0",
-                "extend": "^3.0.2",
-                "gaxios": "^4.0.0",
-                "google-auth-library": "^7.0.0",
-                "pumpify": "^2.0.0",
-                "stream-events": "^1.0.4"
-            },
-            "bin": {
-                "gcs-upload": "build/src/cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/configstore": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-            "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-            "dependencies": {
-                "dot-prop": "^5.2.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^3.0.0",
-                "unique-string": "^2.0.0",
-                "write-file-atomic": "^3.0.0",
-                "xdg-basedir": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/crypto-random-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/dot-prop": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-            "dependencies": {
-                "is-obj": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/is-obj": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "engines": {
                 "node": ">=8"
             },
@@ -5175,34 +5131,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/gcs-resumable-upload/node_modules/unique-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+        "node_modules/gcp-metadata": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+            "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
             "dependencies": {
-                "crypto-random-string": "^2.0.0"
+                "gaxios": "^6.0.0",
+                "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/write-file-atomic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "is-typedarray": "^1.0.0",
-                "signal-exit": "^3.0.2",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
-        "node_modules/gcs-resumable-upload/node_modules/xdg-basedir": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-            "engines": {
-                "node": ">=8"
+                "node": ">=14"
             }
         },
         "node_modules/gensync": {
@@ -5370,60 +5308,19 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.1.2.tgz",
-            "integrity": "sha512-FMipHgfe2u1LzWsf2n9zEB9KsJ8M3n8OYTHbHtlkzPCyo7IknXQR5X99nfvwUHGuX+iEpihUZxDuPm7+qBYeXg==",
+            "version": "9.6.2",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.6.2.tgz",
+            "integrity": "sha512-8G5i+uELrRE244PGnTc9UxiWZ2FMWD5jiIe9P2XSxCvXv/0ip/phjeHSE4bhJnLBdJb+Bu/Gj9Lr33TmDnbAiw==",
             "dependencies": {
-                "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^4.0.0",
-                "gcp-metadata": "^4.2.0",
-                "gtoken": "^5.0.4",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        },
-        "node_modules/google-p12-pem": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.0.tgz",
-            "integrity": "sha512-JUtEHXL4DY/N+xhlm7TC3qL797RPAtk0ZGXNs3/gWyiDHYoA/8Rjes0pztkda+sZv4ej1EoO2KhWgW5V9KTrSQ==",
-            "dependencies": {
-                "node-forge": "^0.10.0"
-            },
-            "bin": {
-                "gp12-pem": "build/src/bin/gp12-pem.js"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/got": {
@@ -5472,16 +5369,15 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "node_modules/gtoken": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.0.tgz",
-            "integrity": "sha512-mCcISYiaRZrJpfqOs0QWa6lfEM/C1V9ASkzFmuz43XBb5s1Vynh+CZy1ECeeJXVGx2PRByjYzb4Y4/zr1byr0w==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
             "dependencies": {
-                "gaxios": "^4.0.0",
-                "google-p12-pem": "^3.0.3",
+                "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/has": {
@@ -5609,11 +5505,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/hash-stream-validation": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-            "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
-        },
         "node_modules/hasha": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -5638,11 +5529,11 @@
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "dependencies": {
-                "@tootallnate/once": "1",
+                "@tootallnate/once": "2",
                 "agent-base": "6",
                 "debug": "4"
             },
@@ -7159,14 +7050,14 @@
             }
         },
         "node_modules/mime": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-            "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
             "bin": {
                 "mime": "cli.js"
             },
             "engines": {
-                "node": ">=4.0.0"
+                "node": ">=10.0.0"
             }
         },
         "node_modules/mime-db": {
@@ -7192,6 +7083,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7413,19 +7305,22 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
             "engines": {
                 "node": "4.x || >=6.0.0"
-            }
-        },
-        "node_modules/node-forge": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-            "engines": {
-                "node": ">= 6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/node-releases": {
@@ -7773,6 +7668,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -8692,16 +8588,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/pumpify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-            "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-            "dependencies": {
-                "duplexify": "^4.1.1",
-                "inherits": "^2.0.3",
-                "pump": "^3.0.0"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -9207,22 +9093,24 @@
             }
         },
         "node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/retry-request": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-            "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+            "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
             "dependencies": {
-                "debug": "^4.1.1"
+                "@types/request": "^2.48.8",
+                "extend": "^3.0.2",
+                "teeny-request": "^9.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=14"
             }
         },
         "node_modules/reusify": {
@@ -9537,11 +9425,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/snakeize": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-            "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
         },
         "node_modules/snapdragon": {
             "version": "0.8.2",
@@ -9981,9 +9864,9 @@
             }
         },
         "node_modules/stream-shift": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+            "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -10151,10 +10034,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "node_modules/stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-            "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+            "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
         },
         "node_modules/supertap": {
             "version": "1.0.0",
@@ -10376,18 +10264,30 @@
             }
         },
         "node_modules/teeny-request": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.0.tgz",
-            "integrity": "sha512-hPfSc05a7Mf3syqVhSkrVMb844sMiP60MrfGMts3ft6V6UlSkEIGQzgwf0dy1KjdE3FV2lJ5s7QCBFcaoQLA6g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+            "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
             "dependencies": {
-                "http-proxy-agent": "^4.0.0",
+                "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^2.6.9",
                 "stream-events": "^1.0.5",
-                "uuid": "^8.0.0"
+                "uuid": "^9.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            }
+        },
+        "node_modules/teeny-request/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/term-size": {
@@ -10504,6 +10404,11 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/trim-newlines": {
             "version": "2.0.0",
@@ -11025,6 +10930,11 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
         "node_modules/well-known-symbols": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
@@ -11032,6 +10942,15 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -11841,33 +11760,10 @@
                 }
             }
         },
-        "@google-cloud/common": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
-            "integrity": "sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==",
-            "requires": {
-                "@google-cloud/projectify": "^2.0.0",
-                "@google-cloud/promisify": "^2.0.0",
-                "arrify": "^2.0.1",
-                "duplexify": "^4.1.1",
-                "ent": "^2.2.0",
-                "extend": "^3.0.2",
-                "google-auth-library": "^7.0.2",
-                "retry-request": "^4.1.1",
-                "teeny-request": "^7.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-                }
-            }
-        },
         "@google-cloud/paginator": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.5.tgz",
-            "integrity": "sha512-N4Uk4BT1YuskfRhKXBs0n9Lg2YTROZc6IMpkO/8DIHODtm5s3xY8K5vVBo23v/2XulY3azwITQlYWgT4GdLsUw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz",
+            "integrity": "sha512-87aeg6QQcEPxGCOthnpUjvw4xAZ57G7pL8FS0C4e/81fr3FjkpUpibf1s2v5XGyGhUVGF4Jfg7yEcxqn2iUw1w==",
             "requires": {
                 "arrify": "^2.0.0",
                 "extend": "^3.0.2"
@@ -11881,53 +11777,39 @@
             }
         },
         "@google-cloud/projectify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.0.tgz",
-            "integrity": "sha512-qbpidP/fOvQNz3nyabaVnZqcED1NNzf7qfeOlgtAZd9knTwY+KtsGRkYpiQzcATABy4gnGP2lousM3S0nuWVzA=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+            "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA=="
         },
         "@google-cloud/promisify": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
-            "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+            "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="
         },
         "@google-cloud/storage": {
-            "version": "5.8.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.5.tgz",
-            "integrity": "sha512-i0gB9CRwQeOBYP7xuvn14M40LhHCwMjceBjxE4CTvsqL519sVY5yVKxLiAedHWGwUZHJNRa7Q2CmNfkdRwVNPg==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.7.0.tgz",
+            "integrity": "sha512-EMCEY+6JiIkx7Dt8NXVGGjy1vRdSGdHkoqZoqjJw7cEBkT7ZkX0c7puedfn1MamnzW5SX4xoa2jVq5u7OWBmkQ==",
             "requires": {
-                "@google-cloud/common": "^3.6.0",
-                "@google-cloud/paginator": "^3.0.0",
-                "@google-cloud/promisify": "^2.0.0",
-                "arrify": "^2.0.0",
-                "async-retry": "^1.3.1",
+                "@google-cloud/paginator": "^5.0.0",
+                "@google-cloud/projectify": "^4.0.0",
+                "@google-cloud/promisify": "^4.0.0",
+                "abort-controller": "^3.0.0",
+                "async-retry": "^1.3.3",
                 "compressible": "^2.0.12",
-                "date-and-time": "^1.0.0",
                 "duplexify": "^4.0.0",
-                "extend": "^3.0.2",
-                "gaxios": "^4.0.0",
-                "gcs-resumable-upload": "^3.1.4",
-                "get-stream": "^6.0.0",
-                "hash-stream-validation": "^0.2.2",
-                "mime": "^2.2.0",
+                "ent": "^2.2.0",
+                "fast-xml-parser": "^4.3.0",
+                "gaxios": "^6.0.2",
+                "google-auth-library": "^9.0.0",
+                "mime": "^3.0.0",
                 "mime-types": "^2.0.8",
-                "onetime": "^5.1.0",
                 "p-limit": "^3.0.1",
-                "pumpify": "^2.0.0",
-                "snakeize": "^0.1.0",
-                "stream-events": "^1.0.1",
-                "xdg-basedir": "^4.0.0"
+                "retry-request": "^7.0.0",
+                "teeny-request": "^9.0.0",
+                "uuid": "^8.0.0"
             },
             "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-                },
-                "get-stream": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-                },
                 "p-limit": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11935,11 +11817,6 @@
                     "requires": {
                         "yocto-queue": "^0.1.0"
                     }
-                },
-                "xdg-basedir": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-                    "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
                 }
             }
         },
@@ -12023,9 +11900,14 @@
             }
         },
         "@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+        },
+        "@types/caseless": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
         },
         "@types/glob": {
             "version": "7.1.3",
@@ -12052,14 +11934,29 @@
         "@types/node": {
             "version": "15.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-            "dev": true
+            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
         },
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
             "dev": true
+        },
+        "@types/request": {
+            "version": "2.48.12",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+            "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+            "requires": {
+                "@types/caseless": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "form-data": "^2.5.0"
+            }
+        },
+        "@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
         },
         "abort-controller": {
             "version": "3.0.0",
@@ -12320,12 +12217,17 @@
             "dev": true
         },
         "async-retry": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-            "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+            "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
             "requires": {
-                "retry": "0.12.0"
+                "retry": "0.13.1"
             }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "at-least-node": {
             "version": "1.0.0",
@@ -12872,9 +12774,9 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bignumber.js": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
         },
         "binary-extensions": {
             "version": "1.13.1",
@@ -13015,7 +12917,7 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -13121,9 +13023,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001237",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-            "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==",
+            "version": "1.0.30001584",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001584.tgz",
+            "integrity": "sha512-LOz7CCQ9M1G7OjJOF9/mzmqmj3jE/7VOmrfw6Mgs0E8cjOsbRXQJHsPBfmBOXDskXKrHLyyW3n7kpDW/4BsfpQ==",
             "dev": true
         },
         "capture-stack-trace": {
@@ -13550,6 +13452,14 @@
             "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "commander": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -13771,11 +13681,6 @@
                 "array-find-index": "^1.0.1"
             }
         },
-        "date-and-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.1.tgz",
-            "integrity": "sha512-7u+uNfnjWkX+YFQfivvW24TjaJG6ahvTrfw1auq7KlC7osuGcZBIWGBvB9UcENjH6JnLVhMqlRripk1dSHjAUA=="
-        },
         "date-time": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
@@ -13786,9 +13691,9 @@
             }
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
             },
@@ -13974,6 +13879,11 @@
                 }
             }
         },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
         "delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -14033,9 +13943,9 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "duplexify": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-            "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "requires": {
                 "end-of-stream": "^1.4.1",
                 "inherits": "^2.0.3",
@@ -14044,9 +13954,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -14119,7 +14029,7 @@
         "ent": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-            "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+            "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
         },
         "equal-length": {
             "version": "1.0.1",
@@ -15039,10 +14949,13 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
-        "fast-text-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+        "fast-xml-parser": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz",
+            "integrity": "sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==",
+            "requires": {
+                "strnum": "^1.0.5"
+            }
         },
         "fastq": {
             "version": "1.11.0",
@@ -15117,6 +15030,16 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
+        },
+        "form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -15242,110 +15165,47 @@
             }
         },
         "gaxios": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-            "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.2.0.tgz",
+            "integrity": "sha512-H6+bHeoEAU5D6XNc6mPKeN5dLZqEDs9Gpk6I+SZBEzK5So58JVrHPmevNi35fRl1J9Y5TaeLW0kYx3pCJ1U2mQ==",
             "requires": {
-                "abort-controller": "^3.0.0",
                 "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^7.0.1",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.3.0"
+                "node-fetch": "^2.6.9"
             },
             "dependencies": {
+                "agent-base": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+                    "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
+                    }
+                },
                 "is-stream": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
                 }
             }
         },
         "gcp-metadata": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-            "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+            "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
             "requires": {
-                "gaxios": "^4.0.0",
+                "gaxios": "^6.0.0",
                 "json-bigint": "^1.0.0"
-            }
-        },
-        "gcs-resumable-upload": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.2.0.tgz",
-            "integrity": "sha512-k6OAkrO0N1zgvwTRxgCC43K9BMvNUBhZkkFELsMSlgAVs7Sd9C1TA9pmDLBZmFBN8sdvrObsSbCfOOFnHULRvA==",
-            "requires": {
-                "abort-controller": "^3.0.0",
-                "configstore": "^5.0.0",
-                "extend": "^3.0.2",
-                "gaxios": "^4.0.0",
-                "google-auth-library": "^7.0.0",
-                "pumpify": "^2.0.0",
-                "stream-events": "^1.0.4"
-            },
-            "dependencies": {
-                "configstore": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-                    "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-                    "requires": {
-                        "dot-prop": "^5.2.0",
-                        "graceful-fs": "^4.1.2",
-                        "make-dir": "^3.0.0",
-                        "unique-string": "^2.0.0",
-                        "write-file-atomic": "^3.0.0",
-                        "xdg-basedir": "^4.0.0"
-                    }
-                },
-                "crypto-random-string": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-                    "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
-                },
-                "dot-prop": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-                    "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-                    "requires": {
-                        "is-obj": "^2.0.0"
-                    }
-                },
-                "is-obj": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-                    "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
-                },
-                "make-dir": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-                    "requires": {
-                        "semver": "^6.0.0"
-                    }
-                },
-                "unique-string": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-                    "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-                    "requires": {
-                        "crypto-random-string": "^2.0.0"
-                    }
-                },
-                "write-file-atomic": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-                    "requires": {
-                        "imurmurhash": "^0.1.4",
-                        "is-typedarray": "^1.0.0",
-                        "signal-exit": "^3.0.2",
-                        "typedarray-to-buffer": "^3.1.5"
-                    }
-                },
-                "xdg-basedir": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-                    "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
-                }
             }
         },
         "gensync": {
@@ -15469,47 +15329,16 @@
             }
         },
         "google-auth-library": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.1.2.tgz",
-            "integrity": "sha512-FMipHgfe2u1LzWsf2n9zEB9KsJ8M3n8OYTHbHtlkzPCyo7IknXQR5X99nfvwUHGuX+iEpihUZxDuPm7+qBYeXg==",
+            "version": "9.6.2",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.6.2.tgz",
+            "integrity": "sha512-8G5i+uELrRE244PGnTc9UxiWZ2FMWD5jiIe9P2XSxCvXv/0ip/phjeHSE4bhJnLBdJb+Bu/Gj9Lr33TmDnbAiw==",
             "requires": {
-                "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^4.0.0",
-                "gcp-metadata": "^4.2.0",
-                "gtoken": "^5.0.4",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-                }
-            }
-        },
-        "google-p12-pem": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.0.tgz",
-            "integrity": "sha512-JUtEHXL4DY/N+xhlm7TC3qL797RPAtk0ZGXNs3/gWyiDHYoA/8Rjes0pztkda+sZv4ej1EoO2KhWgW5V9KTrSQ==",
-            "requires": {
-                "node-forge": "^0.10.0"
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
             }
         },
         "got": {
@@ -15551,12 +15380,11 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "gtoken": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.0.tgz",
-            "integrity": "sha512-mCcISYiaRZrJpfqOs0QWa6lfEM/C1V9ASkzFmuz43XBb5s1Vynh+CZy1ECeeJXVGx2PRByjYzb4Y4/zr1byr0w==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
             "requires": {
-                "gaxios": "^4.0.0",
-                "google-p12-pem": "^3.0.3",
+                "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
             }
         },
@@ -15656,11 +15484,6 @@
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
         },
-        "hash-stream-validation": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-            "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
-        },
         "hasha": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -15682,11 +15505,11 @@
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
         "http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "requires": {
-                "@tootallnate/once": "1",
+                "@tootallnate/once": "2",
                 "agent-base": "6",
                 "debug": "4"
             }
@@ -16824,9 +16647,9 @@
             }
         },
         "mime": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-            "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
         },
         "mime-db": {
             "version": "1.48.0",
@@ -16844,7 +16667,8 @@
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
         },
         "mimic-response": {
             "version": "2.1.0",
@@ -17022,14 +16846,12 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        },
-        "node-forge": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
         },
         "node-releases": {
             "version": "1.1.73",
@@ -17304,6 +17126,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
@@ -18001,16 +17824,6 @@
                 "once": "^1.3.1"
             }
         },
-        "pumpify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-            "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-            "requires": {
-                "duplexify": "^4.1.1",
-                "inherits": "^2.0.3",
-                "pump": "^3.0.0"
-            }
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -18393,16 +18206,18 @@
             "dev": true
         },
         "retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
         },
         "retry-request": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-            "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+            "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
             "requires": {
-                "debug": "^4.1.1"
+                "@types/request": "^2.48.8",
+                "extend": "^3.0.2",
+                "teeny-request": "^9.0.0"
             }
         },
         "reusify": {
@@ -18617,11 +18432,6 @@
             "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
             "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
             "dev": true
-        },
-        "snakeize": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-            "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -19000,9 +18810,9 @@
             }
         },
         "stream-shift": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+            "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
         },
         "string_decoder": {
             "version": "1.1.1",
@@ -19131,10 +18941,15 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-            "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+            "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
         },
         "supertap": {
             "version": "1.0.0",
@@ -19312,15 +19127,22 @@
             }
         },
         "teeny-request": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.0.tgz",
-            "integrity": "sha512-hPfSc05a7Mf3syqVhSkrVMb844sMiP60MrfGMts3ft6V6UlSkEIGQzgwf0dy1KjdE3FV2lJ5s7QCBFcaoQLA6g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+            "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
             "requires": {
-                "http-proxy-agent": "^4.0.0",
+                "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^2.6.9",
                 "stream-events": "^1.0.5",
-                "uuid": "^8.0.0"
+                "uuid": "^9.0.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
             }
         },
         "term-size": {
@@ -19412,6 +19234,11 @@
             "requires": {
                 "is-number": "^7.0.0"
             }
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "trim-newlines": {
             "version": "2.0.0",
@@ -19820,11 +19647,25 @@
                 "defaults": "^1.0.3"
             }
         },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
         "well-known-symbols": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
             "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
             "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bin": "./index.js",
     "license": "MIT",
     "dependencies": {
-        "@google-cloud/storage": "5.8.5",
+        "@google-cloud/storage": "7.7.0",
         "@supercharge/promise-pool": "1.7.0",
         "chalk": "4.1.1",
         "fs-readdir-recursive": "1.1.0",


### PR DESCRIPTION
When uploading files with node 20 I get an error. By forcing node to use the latest version of @google-cloud/storage (7.7.0) the problems goes away.

```
---Uploading 4 files---
/home/travis/build/finn/organisation-frontend/node_modules/.pnpm/stream-shift@1.0.1/node_modules/stream-shift/index.js:16
    return state.buffer[0].length
                           ^
TypeError: Cannot read properties of null (reading 'length')
    at getStateLength (/home/travis/build/finn/organisation-frontend/node_modules/.pnpm/stream-shift@1.0.1/node_modules/stream-shift/index.js:16:28)
    at shift (/home/travis/build/finn/organisation-frontend/node_modules/.pnpm/stream-shift@1.0.1/node_modules/stream-shift/index.js:6:99)
    at Duplexify._forward (/home/travis/build/finn/organisation-frontend/node_modules/.pnpm/duplexify@4.1.2/node_modules/duplexify/index.js:170:35)
    at PassThrough.onreadable (/home/travis/build/finn/organisation-frontend/node_modules/.pnpm/duplexify@4.1.2/node_modules/duplexify/index.js:136:10)
    at PassThrough.emit (node:events:518:28)
    at emitReadable_ (node:internal/streams/readable:832:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
Node.js v20.11.0
```